### PR TITLE
Pin serverless version to docker tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM aligent/serverless:latest
+ARG SERVERLESS_VERSION
+FROM aligent/serverless:${SERVERLESS_VERSION}
 
 COPY pipe /
 RUN apk add --no-cache wget

--- a/hooks/build
+++ b/hooks/build
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build --build-arg PHP_VERSION=$DOCKER_TAG -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+docker build --build-arg SERVERLESS_VERSION=$DOCKER_TAG -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
Update the DockerHub build hook to inject a `SERVERLESS_VERSION` build arg which is set to the Docker image tag.

Three build tags have been configured in Dockerhub:
latest,2,1