### PR TITLE
Add support for CFN role injection based on env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,12 @@ FROM aligent/serverless:${SERVERLESS_VERSION}
 
 COPY pipe /
 RUN apk add --no-cache wget
+
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+RUN python3 -m ensurepip
+RUN pip3 install --no-cache --upgrade pip setuptools yq
+
 RUN wget -O /common.sh https://bitbucket.org/bitbucketpipelines/bitbucket-pipes-toolkit-bash/raw/0.6.0/common.sh
 
 RUN chmod a+x /*.sh

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Add the following your `bitbucket-pipelines.yml` file:
 | DEBUG                 | (Optional) Turn on extra debug information. Default: `false`. |
 | AWS_ACCESS_KEY_ID     | Injects AWS Access key |
 | AWS_SECRET_ACCESS_KEY | Injects AWS Secret key |
+| CFN_ROLE              | [CloudFormation service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html) to use for deployment|
 | STAGE                 | Define the stage to deploy. If not provided use branch name |
 
 ## Development


### PR DESCRIPTION
Adds CFN role injection as part of the deployment process if a `CFN_ROLE` environment variable is provided.

This will overwrite the CFN role provided by `serverless.yaml`  if `CFN_ROLE` is present.