### PR TITLE
DO-1372: Add -Y flag to preserve tags and styles

### DIFF
--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -53,7 +53,7 @@ inject_cfn_role() {
 
      if [ $CFN_ROLE ]
      then
-          mv serverless.yml /tmp/serverless.yml && yq -y 'del(.provider.cfnRole) | .provider.iam.deploymentRole=env.CFN_ROLE'  /tmp/serverless.yml > ./serverless.yml
+          mv serverless.yml /tmp/serverless.yml && yq -Y -y 'del(.provider.cfnRole) | .provider.iam.deploymentRole=env.CFN_ROLE'  /tmp/serverless.yml > ./serverless.yml
      fi
 }
 


### PR DESCRIPTION
Currently custom tags are being stripped during the deployment process. This seems to be during the CFN role injection phase where yq is run. Adding the `-Y` flag will preserve these tags. [See here for docs.](https://github.com/kislyuk/yq#preserving-tags-and-styles-using-the--y---yaml-roundtrip-option)
