### PR TITLE
Add flag to use Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Add the following your `bitbucket-pipelines.yml` file:
 | AWS_SECRET_ACCESS_KEY | Injects AWS Secret key |
 | CFN_ROLE              | [CloudFormation service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html) to use for deployment|
 | STAGE                 | Define the stage to deploy. If not provided use branch name |
+| YARN                  | Use yarn to resolve dependencies |
 
 ## Development
 

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -33,10 +33,14 @@ install_dependencies() {
           ls -alth ./node_modules || true
      fi
 
-     unset NPM_CONFIG_USER
-     npm config set user 0
-     npm config set unsafe-perm true
-     npm ci
+     if [ $YARN ]
+     then
+          yarn install --frozen-lockfile
+     else
+          npm config set user 0
+          npm config set unsafe-perm true
+          npm ci
+     fi
 }
 
 inject_cfn_role() {

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -33,6 +33,7 @@ install_dependencies() {
           ls -alth ./node_modules || true
      fi
 
+     unset NPM_CONFIG_USER
      npm config set user 0
      npm config set unsafe-perm true
      npm ci


### PR DESCRIPTION
When a package runs install scripts globally the pipe fails

![image](https://user-images.githubusercontent.com/40108018/186851096-e8c9e5bf-61c9-4a88-b7e0-c87a7c038fe9.png)

I've searched through multiple forums but only found a solution in some obscure PR comment and the only resolution mentioned by **Atlassian** is `unset NPM_CONFIG_USER`

https://github.com/expo/sentry-expo/pull/26#issuecomment-453822980
