### PR TITLE
Revert to use yq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ ARG SERVERLESS_VERSION
 FROM aligent/serverless:${SERVERLESS_VERSION}
 
 ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 git && ln -sf python3 /usr/bin/python
+RUN apk add --update --no-cache python3 git jq && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade pip setuptools
+RUN pip3 install --no-cache --upgrade pip setuptools yq
 
 COPY pipe requirements.txt pipe.yml /
 RUN chmod a+x /pipe.py


### PR DESCRIPTION
Update to use yq instead of pyyaml to repalce the deployment CFN role as the pyyaml baseloader does not support our cloudformation attributes or types