### PR TITLE
Badges Upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,20 @@ Add the following your `bitbucket-pipelines.yml` file:
 ```
 ## Variables
 
-| Variable              | Usage                                                       |
-| --------------------- | ----------------------------------------------------------- |
-| DEBUG                 | (Optional) Turn on extra debug information. Default: `false`. |
-| AWS_ACCESS_KEY_ID     | Injects AWS Access key |
-| AWS_SECRET_ACCESS_KEY | Injects AWS Secret key |
-| CFN_ROLE              | [CloudFormation service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html) to use for deployment|
-| STAGE                 | Define the stage to deploy. If not provided use branch name |
-| YARN                  | Use yarn to resolve dependencies |
+| Variable              | Usage                                                                                                                                                     |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DEBUG                 | (Optional) Turn on extra debug information. Default: `false`.                                                                                             |
+| AWS_ACCESS_KEY_ID     | Injects AWS Access key                                                                                                                                    |
+| AWS_SECRET_ACCESS_KEY | Injects AWS Secret key                                                                                                                                    |
+| CFN_ROLE              | (Optional) [CloudFormation service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html) to use for deployment |
+| STAGE                 | (Optional) Define the stage to deploy. If not provided use branch name                                                                                    |
+| YARN                  | (Optional) Use yarn to resolve dependencies                                                                                                               |
+| UPLOAD_BADGE          | (Optional) Whether or not to upload a deployment badge to the repositories downloads section.                                                             |
+| TIMEZONE              | (Optional) Which timezone the time in the badge should use (Default: 'Australia/Adelaide')                                                                |
+| APP_USERNAME          | (Optional) The user to upload the badge as. Required if UPLOAD_BADGE is set to true.                                                                      |
+| APP_PASSWORD          | (Optional) The app password of the user uploading the badge. Required if UPLOAD_BADGE is set to true.                                                     |
+
+See here: https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/ for how to generate an app password.
 
 ## Development
 

--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -179,21 +179,21 @@ class ServerlessDeploy(Pipe):
 
         deployment_stage = self.stage or self.bitbucket_branch
         self.log_debug(f'Deploying {deployment_stage}')
-        # deploy = subprocess.run(
-        #         args=[
-        #                 "/serverless/node_modules/serverless/bin/serverless.js",
-        #                 "deploy",
-        #                 "--stage",
-        #                 deployment_stage,
-        #                 "--aws-profile",
-        #                 "bitbucket-deployer",
-        #                 "--conceal",
-        #                 "--force"
-        #             ],
-        #         universal_newlines=True)
+        deploy = subprocess.run(
+                args=[
+                        "/serverless/node_modules/serverless/bin/serverless.js",
+                        "deploy",
+                        "--stage",
+                        deployment_stage,
+                        "--aws-profile",
+                        "bitbucket-deployer",
+                        "--conceal",
+                        "--force"
+                    ],
+                universal_newlines=True)
 
-        # if deploy.returncode != 0:
-        #         raise Exception("Failed to deploy the service.")
+        if deploy.returncode != 0:
+                raise Exception("Failed to deploy the service.")
 
     def run(self):
         super().run()

--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -102,9 +102,9 @@ class ServerlessDeploy(Pipe):
 
         update = subprocess.run(
             args=[
-                    "yq", 
-                    "-Yi", 
-                    "-yi", 
+                    "yq",
+                    "-Y",
+                    "-i",
                     f'del(.provider.cfnRole) | .provider.iam.deploymentRole="{self.cfn_role}"', 
                     "serverless.yml"
                 ],

--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -198,7 +198,7 @@ class ServerlessDeploy(Pipe):
     def run(self):
         super().run()
         try: 
-            # self.install_dependencies()
+            self.install_dependencies()
             self.inject_aws_creds()
             self.inject_cfn_role()
             self.deploy()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ junitparser
 git+https://github.com/aligent/bitbucket-manager
 bitbucket-pipes-toolkit==3.2.1
 pyyaml
+pybadges
+pytz


### PR DESCRIPTION
This PR adds the ability to upload deployment badges to the repos downloads section. This badge can then be referenced in confluence or jira to monitor the deployment status of the branch.

Example Badge:
![production_status](https://user-images.githubusercontent.com/7251527/199659891-1ceec67e-d4f7-4869-9629-7714aba2e6ab.svg)
